### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update -y
 RUN apt-get install -y google-chrome-stable
 
 # Set up Chromedriver Environment variables
-ENV CHROMEDRIVER_VERSION 99.0.4844.51
+ENV CHROMEDRIVER_VERSION 100.0.4896.60
 ENV CHROMEDRIVER_DIR /chromedriver
 RUN mkdir $CHROMEDRIVER_DIR
 


### PR DESCRIPTION
Correct chrome driver version for Chrome 100+ is 100.0.4896.60.
apt-get install -y google-chrome-stable will now install chrome 100,*, not 99.*.